### PR TITLE
Add dataset deletion tests and restrict deletion access to superusers

### DIFF
--- a/app/staticfiles/admin/css/widgets.css
+++ b/app/staticfiles/admin/css/widgets.css
@@ -49,7 +49,7 @@
     padding: 8px;
 }
 
-.aligned .selector-chosen-title label {
+.selector-chosen-title label {
     color: var(--header-link-color);
     width: 100%;
 }
@@ -60,7 +60,7 @@
     padding: 8px;
 }
 
-.aligned .selector-available-title label {
+.selector-available-title label {
     width: 100%;
 }
 

--- a/app/templates/datasets/dataset_detail.html
+++ b/app/templates/datasets/dataset_detail.html
@@ -44,6 +44,12 @@
                         {% trans "Manage Projects" %}
                     </a>
                     {% endif %}
+                    {% if user.is_superuser %}
+                    <a href="{% url 'datasets:dataset_delete' dataset.pk %}" class="btn btn-outline-danger me-2">
+                        <i class="bi bi-trash me-2"></i>
+                        {% trans "Delete" %}
+                    </a>
+                    {% endif %}
                     <a href="{% url 'datasets:dataset_list' %}" class="btn btn-outline-secondary">
                         <i class="bi bi-arrow-left me-2"></i>
                         {% trans "Back" %}


### PR DESCRIPTION
- Introduced DatasetDeleteViewTests to validate deletion functionality for datasets, ensuring only superusers can access the delete page and perform deletions.
- Updated DatasetDeleteView to enforce superuser-only access, with appropriate error handling for unauthorized users.
- Enhanced dataset_detail.html to conditionally display the delete button for superusers only.
- Added tests for various user roles (regular, staff, unauthenticated) to confirm they cannot delete datasets, ensuring robust access control.