### PR TITLE
Enhance large file upload capabilities and validation

### DIFF
--- a/app/datasets/forms.py
+++ b/app/datasets/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models import Q
 from .models import Dataset, DatasetCategory, DatasetVersion, Comment, Publisher, DatasetAnalysis
@@ -285,7 +286,13 @@ class DatasetVersionForm(forms.ModelForm):
         # Add help text for fields
         self.fields['version_number'].help_text = 'Use semantic versioning (e.g., 1.0, 1.1, 2.0)'
         self.fields['description'].help_text = 'Optional: Describe what changed in this version'
-        self.fields['files'].help_text = 'Upload one or more files for this version (CSV, SPSS (.sav, .zsav, .por), Stata (.dta), R (.rds), JSON, Excel, TXT, ZIP, TAR.GZ, GPKG, Shapefile, GeoJSON, KML/KMZ, Raster formats, File/Personal Geodatabase, Esri Layer Files, Esri Map Packages, QGIS Project Files, QML, SpatiaLite, SQL, PDF formats supported, max 1GB per file)'
+        max_upload_gb = settings.MAX_DATASET_UPLOAD_SIZE // (1024 * 1024 * 1024)
+        self.fields['files'].help_text = (
+            'Upload one or more files for this version (CSV, SPSS (.sav, .zsav, .por), Stata (.dta), R (.rds), '
+            'JSON, Excel, TXT, ZIP, TAR.GZ, GPKG, Shapefile, GeoJSON, KML/KMZ, Raster formats, File/Personal '
+            f'Geodatabase, Esri Layer Files, Esri Map Packages, QGIS Project Files, QML, SpatiaLite, SQL, PDF '
+            f'formats supported, max {max_upload_gb}GB total)'
+        )
         self.fields['file_url'].help_text = 'External URL where the file can be accessed'
         self.fields['file_url_description'].help_text = 'Optional: Describe where the file is located'
         self.fields['file_size_text'].help_text = 'Human-readable file size (e.g., "2.5 MB", "1.2 GB")'
@@ -325,14 +332,28 @@ class DatasetVersionForm(forms.ModelForm):
             if file_size_text:
                 raise forms.ValidationError('File size will be calculated automatically when uploading.')
             
+            max_upload_size = settings.MAX_DATASET_UPLOAD_SIZE
+            max_upload_gb = max_upload_size // (1024 * 1024 * 1024)
+
             for upload in uploaded_files:
-                max_file_size = 10 * 1024 * 1024 * 1024  # 10GB
-                if upload.size > max_file_size:
+                if upload.size > max_upload_size:
                     size_gb = upload.size / (1024 * 1024 * 1024)
-                    self.add_error('files', f'File "{upload.name}" ({size_gb:.2f} GB) exceeds the 10GB size limit.')
-                    raise forms.ValidationError('Each uploaded file must be 10GB or smaller.')
+                    self.add_error(
+                        'files',
+                        f'File "{upload.name}" ({size_gb:.2f} GB) exceeds the {max_upload_gb}GB size limit.',
+                    )
+                    raise forms.ValidationError(f'Each uploaded file must be {max_upload_gb}GB or smaller.')
+
                 total_upload_size += upload.size
-            
+
+            if total_upload_size > max_upload_size:
+                total_gb = total_upload_size / (1024 * 1024 * 1024)
+                self.add_error(
+                    'files',
+                    f'Total upload size ({total_gb:.2f} GB) exceeds the {max_upload_gb}GB limit.',
+                )
+                raise forms.ValidationError(f'Total upload size must be {max_upload_gb}GB or smaller.')
+
             # Update file_size field with total upload size
             self.instance.file_size = total_upload_size
             

--- a/app/datasets/tests.py
+++ b/app/datasets/tests.py
@@ -333,6 +333,59 @@ class DatasetVersionFormTests(TestCase):
         self.assertFalse(form.is_valid())
         self.assertIn('Please do not upload files when using the external URL method.', form.non_field_errors())
 
+    def test_form_rejects_oversized_file_upload(self):
+        """Ensure files larger than MAX_DATASET_UPLOAD_SIZE are rejected."""
+        from unittest.mock import patch
+        from django.conf import settings
+
+        oversized_file = SimpleUploadedFile('large.csv', b'data')
+        oversized_file.size = settings.MAX_DATASET_UPLOAD_SIZE + 1
+
+        form = DatasetVersionForm(
+            data={
+                'version_number': '1.0',
+                'description': 'Too large',
+                'input_method': 'upload',
+                'file_url': '',
+                'file_url_description': '',
+                'file_size_text': '',
+            },
+            files=MultiValueDict({'files': [oversized_file]}),
+            dataset=self.dataset,
+        )
+
+        with patch.object(settings, 'MAX_DATASET_UPLOAD_SIZE', 1024):
+            self.assertFalse(form.is_valid())
+            self.assertIn('files', form.errors)
+
+    def test_form_rejects_oversized_total_upload(self):
+        """Ensure total upload size over MAX_DATASET_UPLOAD_SIZE is rejected."""
+        from unittest.mock import patch
+        from django.conf import settings
+
+        file_one = SimpleUploadedFile('part1.csv', b'data')
+        file_two = SimpleUploadedFile('part2.csv', b'data')
+        file_one.size = 600
+        file_two.size = 600
+
+        form = DatasetVersionForm(
+            data={
+                'version_number': '1.0',
+                'description': 'Total too large',
+                'input_method': 'upload',
+                'file_url': '',
+                'file_url_description': '',
+                'file_size_text': '',
+            },
+            files=MultiValueDict({'files': [file_one, file_two]}),
+            dataset=self.dataset,
+        )
+
+        with patch.object(settings, 'MAX_DATASET_UPLOAD_SIZE', 1000):
+            self.assertFalse(form.is_valid())
+            self.assertIn('files', form.errors)
+            self.assertIn('Total upload size', form.errors['files'][0])
+
     def test_form_accepts_supported_file_formats(self):
         """Test that the form accepts all supported file formats including .dta and .rds"""
         # All supported file formats

--- a/app/datasets/views.py
+++ b/app/datasets/views.py
@@ -560,8 +560,11 @@ class DatasetVersionCreateView(LoginRequiredMixin, CreateView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
+        from django.conf import settings
+
         context = super().get_context_data(**kwargs)
         context['dataset'] = self.dataset
+        context['max_dataset_upload_size'] = settings.MAX_DATASET_UPLOAD_SIZE
         return context
 
 

--- a/app/main/settings.py
+++ b/app/main/settings.py
@@ -241,13 +241,18 @@ LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'
 
 # File Upload Settings
-FILE_UPLOAD_MAX_MEMORY_SIZE = 1024 * 1024 * 1024  # 1GB
-DATA_UPLOAD_MAX_MEMORY_SIZE = 1024 * 1024 * 1024  # 1GB
+MAX_DATASET_UPLOAD_SIZE = 100 * 1024 * 1024 * 1024  # 100GB total request body for dataset versions
+DATA_UPLOAD_MAX_MEMORY_SIZE = MAX_DATASET_UPLOAD_SIZE  # hard request-body cap
+FILE_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # spill to disk above 10MB
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 1000
+FILE_UPLOAD_TEMP_DIR = os.path.join(MEDIA_ROOT, 'tmp')
 
 # Large file upload settings
 FILE_UPLOAD_PERMISSIONS = 0o644
 FILE_UPLOAD_DIRECTORY_PERMISSIONS = 0o755
+
+# Ensure upload temp directory exists on the media volume
+os.makedirs(FILE_UPLOAD_TEMP_DIR, exist_ok=True)
 
 API_URL = ''
 

--- a/app/templates/datasets/dataset_version_form.html
+++ b/app/templates/datasets/dataset_version_form.html
@@ -279,7 +279,7 @@
                         </li>
                         <li class="mb-2">
                             <i class="bi bi-info-circle text-info me-2"></i>
-                            {% trans "Maximum file size: 10GB per upload (supported formats: CSV, JSON, Excel, TXT, ZIP, TAR.GZ, GPKG, Shapefile, GeoJSON, KML/KMZ, Raster formats, File/Personal Geodatabase, Esri Layer Files, Esri Map Packages, QGIS Project Files, QML, SpatiaLite, SQL, SPSS, Stata, R)" %}
+                            {% trans "Maximum total upload size: 100GB (supported formats: CSV, JSON, Excel, TXT, ZIP, TAR.GZ, GPKG, Shapefile, GeoJSON, KML/KMZ, Raster formats, File/Personal Geodatabase, Esri Layer Files, Esri Map Packages, QGIS Project Files, QML, SpatiaLite, SQL, SPSS, Stata, R)" %}
                         </li>
                         <li>
                             <i class="bi bi-check-circle text-success me-2"></i>
@@ -297,6 +297,45 @@
 let uploadedFiles = [];
 let isUploading = false;
 let uploadPromises = [];
+const MAX_DATASET_UPLOAD_SIZE = {{ max_dataset_upload_size }};
+const MAX_DATASET_UPLOAD_SIZE_GB = Math.round(MAX_DATASET_UPLOAD_SIZE / (1024 * 1024 * 1024));
+
+function validateUploadSize(files) {
+    const fileList = Array.from(files || []);
+    let totalSize = 0;
+    const oversizedFiles = [];
+
+    fileList.forEach(file => {
+        totalSize += file.size;
+        if (file.size > MAX_DATASET_UPLOAD_SIZE) {
+            oversizedFiles.push(file);
+        }
+    });
+
+    if (oversizedFiles.length > 0) {
+        const fileDetails = oversizedFiles
+            .map(file => `- ${file.name}: ${formatFileSize(file.size)}`)
+            .join('\n');
+        return {
+            valid: false,
+            message: `{% trans "The following file(s) exceed the maximum allowed size of" %} ${MAX_DATASET_UPLOAD_SIZE_GB} GB:\n\n${fileDetails}`
+        };
+    }
+
+    if (totalSize > MAX_DATASET_UPLOAD_SIZE) {
+        const totalSizeGB = (totalSize / (1024 * 1024 * 1024)).toFixed(2);
+        return {
+            valid: false,
+            message: `{% trans "Total upload size" %}: ${totalSizeGB} GB (${formatFileSize(totalSize)})\n{% trans "Maximum allowed size" %}: ${MAX_DATASET_UPLOAD_SIZE_GB} GB`
+        };
+    }
+
+    return { valid: true };
+}
+
+function showUploadSizeError(message) {
+    alert(message + '\n\n{% trans "Please either:" %}\n1. {% trans "Compress your files before uploading" %}\n2. {% trans "Split into smaller files" %}\n3. {% trans "Contact administrator if you need to upload larger files" %}');
+}
 
 function toggleFileInput() {
     const uploadRadio = document.getElementById('input_method_upload');
@@ -492,6 +531,16 @@ function handleFileSelection() {
             hideUploadProgress();
             return;
         }
+
+        const sizeCheck = validateUploadSize(files);
+        if (!sizeCheck.valid) {
+            e.target.value = '';
+            uploadedFiles = [];
+            uploadPromises = [];
+            hideUploadProgress();
+            showUploadSizeError(sizeCheck.message);
+            return;
+        }
         
         // Clear previous uploads
         uploadedFiles = [];
@@ -558,6 +607,12 @@ function handleFormSubmission() {
         if (!fileInput || !fileInput.files || fileInput.files.length === 0) {
             // No files selected, submit normally (validation will catch this)
             form.submit();
+            return;
+        }
+
+        const sizeCheck = validateUploadSize(fileInput.files);
+        if (!sizeCheck.valid) {
+            showUploadSizeError(sizeCheck.message);
             return;
         }
         
@@ -720,7 +775,7 @@ function handleFormSubmission() {
                     const totalSizeMB = (totalSize / (1024 * 1024)).toFixed(2);
                     const totalSizeGB = (totalSize / (1024 * 1024 * 1024)).toFixed(2);
                     details = `\n\n{% trans "Total file size" %}: ${totalSizeGB} GB (${totalSizeMB} MB)`;
-                    details += `\n{% trans "Maximum allowed size" %}: 10 GB`;
+                    details += `\n{% trans "Maximum allowed size" %}: ${MAX_DATASET_UPLOAD_SIZE_GB} GB`;
                 }
                 
                 errorMessage += details;

--- a/app/templates/documentation.html
+++ b/app/templates/documentation.html
@@ -154,7 +154,7 @@
                     <ul>
                         <li>{% trans "Upload new data files as versions" %}</li>
                         <li>{% trans "Supported formats: CSV, SPSS (.sav, .zsav, .por), Stata (.dta), R (.rds), JSON, Excel, TXT, ZIP, TAR.GZ, GPKG, Shapefile (.shp, .shx, .dbf, etc.), GeoJSON (.geojson, .json), KML/KMZ (.kml, .kmz), Raster formats (.tif, .jpg, .png, .img), File Geodatabase (.gdb), Personal Geodatabase (.mdb), Esri Layer Files (.lyr, .lyrx), Esri Map Packages (.mpk, .mpkx), QGIS Project Files (.qgs, .qgz), QML (.qml), SpatiaLite (.sqlite), SQL (.sql), PDF (.pdf)" %}</li>
-                        <li>{% trans "Maximum file size: 1GB" %}</li>
+                        <li>{% trans "Maximum file size: 100GB" %}</li>
                         <li>{% trans "Each version can have a description of changes" %}</li>
                         <li>{% trans "The latest version becomes the current version automatically" %}</li>
                     </ul>
@@ -413,7 +413,7 @@
                     <h5>{% trans "Technical Requirements" %}</h5>
                     <ul>
                         <li>{% trans "Supported file formats: CSV, SPSS (.sav, .zsav, .por), Stata (.dta), R (.rds), JSON, Excel, TXT, ZIP, TAR.GZ, GPKG, Shapefile, GeoJSON, KML/KMZ, Raster formats, File/Personal Geodatabase, Esri Layer Files, Esri Map Packages, QGIS Project Files, QML, SpatiaLite, SQL, PDF" %}</li>
-                        <li>{% trans "Maximum file size: 1GB" %}</li>
+                        <li>{% trans "Maximum file size: 100GB" %}</li>
                         <li>{% trans "Modern web browser with JavaScript enabled" %}</li>
                         <li>{% trans "Stable internet connection for file uploads" %}</li>
                     </ul>

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -311,27 +311,27 @@ docker system prune -f
 
 ### Upload Limits
 
-The application is configured to handle large file uploads up to 1GB:
+The application is configured to handle large file uploads up to 100GB:
 
-- **Nginx**: `client_max_body_size 1G`
-- **Django**: Optimized memory settings for large files
-- **Timeouts**: Extended to 300s (5 minutes) for large uploads
+- **Nginx**: `client_max_body_size 100G`
+- **Django**: `MAX_DATASET_UPLOAD_SIZE` / `DATA_UPLOAD_MAX_MEMORY_SIZE` set to 100GB
+- **Timeouts**: Extended to 3600s (1 hour) for large uploads
 - **Proxy**: Buffering disabled for better performance
 
 ### Configuration Details
 
 **Nginx Settings** (`nginx/nginx.conf`):
 ```nginx
-# Allow large file uploads up to 1GB
-client_max_body_size 1G;
+# Allow large file uploads up to 100GB
+client_max_body_size 100G;
 
 # Increase timeouts for large file uploads
-client_body_timeout 300s;
-client_header_timeout 300s;
-proxy_connect_timeout 300s;
-proxy_send_timeout 300s;
-proxy_read_timeout 300s;
-send_timeout 300s;
+client_body_timeout 3600s;
+client_header_timeout 3600s;
+proxy_connect_timeout 3600s;
+proxy_send_timeout 3600s;
+proxy_read_timeout 3600s;
+send_timeout 3600s;
 
 # Additional proxy settings for large uploads
 proxy_request_buffering off;
@@ -341,8 +341,10 @@ proxy_buffering off;
 **Django Settings** (`app/main/settings.py`):
 ```python
 # File Upload Settings
-FILE_UPLOAD_MAX_MEMORY_SIZE = 100 * 1024 * 1024  # 100MB
-DATA_UPLOAD_MAX_MEMORY_SIZE = 100 * 1024 * 1024  # 100MB
+MAX_DATASET_UPLOAD_SIZE = 100 * 1024 * 1024 * 1024  # 100GB
+DATA_UPLOAD_MAX_MEMORY_SIZE = MAX_DATASET_UPLOAD_SIZE
+FILE_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # spill to disk above 10MB
+FILE_UPLOAD_TEMP_DIR = os.path.join(MEDIA_ROOT, 'tmp')
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 1000
 
 # Large file upload settings
@@ -372,9 +374,9 @@ docker compose -f docker-compose.prod.yml restart nginx
 
 | Component | Limit | Timeout | Status |
 |-----------|-------|---------|---------|
-| **Nginx** | 1GB | 300s | ✅ Configured |
-| **Django Memory** | 100MB | - | ✅ Configured |
-| **Django Data** | 100MB | - | ✅ Configured |
+| **Nginx** | 100GB | 3600s | ✅ Configured |
+| **Django Data** | 100GB | - | ✅ Configured |
+| **Django Memory Spill** | 10MB | - | ✅ Configured |
 | **Proxy Buffering** | Disabled | - | ✅ Optimized |
 
 ### Troubleshooting Upload Issues

--- a/docs/RELOAD_NGINX.md
+++ b/docs/RELOAD_NGINX.md
@@ -43,13 +43,13 @@ After reloading, verify the configuration:
 # Check nginx configuration is loaded
 docker compose exec nginx nginx -T | grep client_max_body_size
 
-# Should show: client_max_body_size 10G;
+# Should show: client_max_body_size 100G;
 ```
 
 ## Current Limits
 
-- **Nginx**: 10GB (`client_max_body_size 10G`)
-- **Django**: 1GB (`FILE_UPLOAD_MAX_MEMORY_SIZE`)
-- **Timeout**: 300 seconds (5 minutes)
+- **Nginx**: 100GB (`client_max_body_size 100G`)
+- **Django**: 100GB (`DATA_UPLOAD_MAX_MEMORY_SIZE` / `MAX_DATASET_UPLOAD_SIZE`)
+- **Timeout**: 3600 seconds (1 hour)
 
-Note: The Django limit is for in-memory uploads. Files larger than this will be written to disk automatically.
+Note: Files larger than `FILE_UPLOAD_MAX_MEMORY_SIZE` (10MB) are written to disk automatically during upload.

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -5,16 +5,16 @@ upstream main {
 server {
     listen 80;
 
-    # Allow large file uploads up to 10GB
-    client_max_body_size 10G;
+    # Allow large file uploads up to 100GB
+    client_max_body_size 100G;
     
     # Increase timeouts for large file uploads
-    client_body_timeout 300s;
-    client_header_timeout 300s;
-    proxy_connect_timeout 300s;
-    proxy_send_timeout 300s;
-    proxy_read_timeout 300s;
-    send_timeout 300s;
+    client_body_timeout 3600s;
+    client_header_timeout 3600s;
+    proxy_connect_timeout 3600s;
+    proxy_send_timeout 3600s;
+    proxy_read_timeout 3600s;
+    send_timeout 3600s;
 
     location / {
         proxy_pass http://main;

--- a/update-nginx.sh
+++ b/update-nginx.sh
@@ -21,8 +21,8 @@ if ! docker info > /dev/null 2>&1; then
 fi
 
 echo "📋 Current nginx configuration changes:"
-echo "  ✅ client_max_body_size increased to 1G"
-echo "  ✅ Timeout settings increased to 300s"
+echo "  ✅ client_max_body_size increased to 100G"
+echo "  ✅ Timeout settings increased to 3600s"
 echo "  ✅ Proxy buffering disabled for large uploads"
 echo ""
 
@@ -72,6 +72,6 @@ echo ""
 echo "🎉 Nginx configuration update completed!"
 echo ""
 echo "📊 Upload limits now configured for:"
-echo "  ✅ Maximum file size: 1GB"
-echo "  ✅ Timeout: 5 minutes (300s)"
+echo "  ✅ Maximum file size: 100GB"
+echo "  ✅ Timeout: 1 hour (3600s)"
 echo "  ✅ Optimized for large file uploads"


### PR DESCRIPTION
- Updated Nginx configuration to allow file uploads up to 100GB, increasing client_max_body_size and timeout settings.
- Modified DatasetVersionForm to validate against the new maximum upload size of 100GB, including error handling for oversized files.
- Adjusted help text in the form to reflect the updated upload limits.
- Added tests to ensure proper rejection of oversized file uploads and total upload size validation.
- Updated documentation to include new upload limits and instructions for reloading Nginx configuration.