### PR TITLE
Add user account invitation functionality

### DIFF
--- a/app/templates/user/email/account_invite_message.html
+++ b/app/templates/user/email/account_invite_message.html
@@ -1,0 +1,58 @@
+{% extends "account/email/base_message.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Your account has been created" %} - {{ site_name }}{% endblock %}
+
+{% block header %}
+<h1 style="margin: 0; font-size: 20px; font-weight: 600; color: #FFFFFF;">{% trans "Welcome to" %} {{ site_name }}</h1>
+{% endblock %}
+
+{% block content %}
+<p style="margin: 0 0 16px 0;">{% trans "Hello" %}{% if user.first_name %}, {{ user.first_name }}{% endif %},</p>
+
+<p style="margin: 0 0 24px 0;">{% blocktrans %}An administrator has created an account for you on {{ site_name }}. Please set your password using the button below before signing in.{% endblocktrans %}</p>
+
+<div class="info-box">
+    <strong style="color: #1A1A1A;">{% trans "Your account details" %}</strong>
+    <table role="presentation" cellpadding="0" cellspacing="0" style="margin-top: 12px; width: 100%;">
+        <tr>
+            <td style="padding: 4px 0; color: #555555;"><strong style="color: #1A1A1A;">{% trans "Username" %}:</strong></td>
+            <td style="padding: 4px 0; color: #1A1A1A;">{{ username }}</td>
+        </tr>
+        <tr>
+            <td style="padding: 4px 0; color: #555555;"><strong style="color: #1A1A1A;">{% trans "Email" %}:</strong></td>
+            <td style="padding: 4px 0; color: #1A1A1A;">{{ email }}</td>
+        </tr>
+        {% if role_name %}
+        <tr>
+            <td style="padding: 4px 0; color: #555555;"><strong style="color: #1A1A1A;">{% trans "Role" %}:</strong></td>
+            <td style="padding: 4px 0; color: #1A1A1A;">{{ role_name }}</td>
+        </tr>
+        {% endif %}
+        <tr>
+            <td style="padding: 4px 0; color: #555555;"><strong style="color: #1A1A1A;">{% trans "Login page" %}:</strong></td>
+            <td style="padding: 4px 0;"><a href="{{ login_url }}" style="color: #0047BB;">{{ login_url }}</a></td>
+        </tr>
+    </table>
+</div>
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+    <tr>
+        <td align="center" style="padding: 8px 0 24px 0;">
+            <a href="{{ password_set_url }}" class="btn" style="background-color: #0047BB; color: #FFFFFF;">
+                {% trans "Set Your Password" %}
+            </a>
+        </td>
+    </tr>
+</table>
+
+<div class="notice">
+    <strong style="color: #1A1A1A;">{% trans "Important:" %}</strong>
+    <p style="margin: 8px 0 0 0;">{% trans "You will not be able to sign in until you have set your password using the link above." %}</p>
+</div>
+
+<p style="margin: 24px 0 8px 0;">{% trans "If the button doesn't work, copy and paste this link into your browser:" %}</p>
+<p style="margin: 0; word-break: break-all;">
+    <a href="{{ password_set_url }}" style="color: #0047BB;">{{ password_set_url }}</a>
+</p>
+{% endblock content %}

--- a/app/templates/user/email/account_invite_message.txt
+++ b/app/templates/user/email/account_invite_message.txt
@@ -1,0 +1,15 @@
+{% load i18n %}{% trans "Hello" %}{% if user.first_name %}, {{ user.first_name }}{% endif %},
+
+{% blocktrans %}An administrator has created an account for you on {{ site_name }}. Please set your password using the link below before signing in.{% endblocktrans %}
+
+{% trans "Your account details" %}:
+{% trans "Username" %}: {{ username }}
+{% trans "Email" %}: {{ email }}
+{% if role_name %}{% trans "Role" %}: {{ role_name }}
+{% endif %}{% trans "Login page" %}: {{ login_url }}
+
+{% trans "Set your password" %}: {{ password_set_url }}
+
+{% trans "Important: You will not be able to sign in until you have set your password using the link above." %}
+
+{% trans "This is an automated message, please do not reply to this email." %}

--- a/app/templates/user/user_form.html
+++ b/app/templates/user/user_form.html
@@ -146,44 +146,9 @@
                             {% endif %}
                         </div>
 
-                        <div class="mb-3">
-                            <label for="{{ form.password1.id_for_label }}" class="form-label">
-                                <i class="bi bi-key me-1"></i>
-                                {% trans "Password" %} <span class="text-danger">*</span>
-                            </label>
-                            <input 
-                                type="password" 
-                                name="{{ form.password1.name }}" 
-                                class="form-control {% if form.password1.errors %}is-invalid{% endif %}"
-                                id="{{ form.password1.id_for_label }}"
-                                placeholder="{% trans 'Enter password' %}"
-                                required
-                            >
-                            {% if form.password1.errors %}
-                                <div class="invalid-feedback">
-                                    {{ form.password1.errors.0 }}
-                                </div>
-                            {% endif %}
-                        </div>
-
-                        <div class="mb-4">
-                            <label for="{{ form.password2.id_for_label }}" class="form-label">
-                                <i class="bi bi-key-fill me-1"></i>
-                                {% trans "Confirm Password" %} <span class="text-danger">*</span>
-                            </label>
-                            <input 
-                                type="password" 
-                                name="{{ form.password2.name }}" 
-                                class="form-control {% if form.password2.errors %}is-invalid{% endif %}"
-                                id="{{ form.password2.id_for_label }}"
-                                placeholder="{% trans 'Confirm password' %}"
-                                required
-                            >
-                            {% if form.password2.errors %}
-                                <div class="invalid-feedback">
-                                    {{ form.password2.errors.0 }}
-                                </div>
-                            {% endif %}
+                        <div class="alert alert-info mb-4">
+                            <i class="bi bi-envelope-check me-2"></i>
+                            {% trans "The new user will receive an email with their login details and a link to set their password." %}
                         </div>
 
                         <!-- Form Actions -->

--- a/app/user/email_utils.py
+++ b/app/user/email_utils.py
@@ -1,0 +1,65 @@
+import logging
+
+from django.conf import settings
+from django.core.mail import send_mail
+from django.template.loader import render_to_string
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from allauth.account.adapter import get_adapter
+from allauth.account.utils import user_pk_to_url_str
+
+logger = logging.getLogger(__name__)
+
+
+def build_password_set_url(user, request=None):
+    """Build an allauth password-set URL for a newly invited user."""
+    adapter = get_adapter()
+    token = adapter.get_token_generator().make_token(user)
+    uid = user_pk_to_url_str(user)
+    path = reverse(
+        'account_reset_password_from_key',
+        kwargs={'uidb36': uid, 'key': token},
+    )
+    if request is not None:
+        return request.build_absolute_uri(path)
+    site_url = getattr(settings, 'SITE_URL', 'http://localhost:8000').rstrip('/')
+    return f'{site_url}{path}'
+
+
+def send_account_invite_email(user, request=None):
+    """Send a welcome email with login details and a link to set the password."""
+    password_set_url = build_password_set_url(user, request=request)
+    site_url = getattr(settings, 'SITE_URL', 'http://localhost:8000').rstrip('/')
+    site_name = getattr(settings, 'SITE_NAME', 'ISR Repository')
+    login_url = f'{site_url}{reverse("account_login")}'
+
+    context = {
+        'user': user,
+        'username': user.username,
+        'email': user.email,
+        'role_name': user.role.name if user.role else None,
+        'site_name': site_name,
+        'site_url': site_url,
+        'login_url': login_url,
+        'password_set_url': password_set_url,
+    }
+
+    subject = _('Your %(site_name)s account has been created') % {'site_name': site_name}
+    html_message = render_to_string('user/email/account_invite_message.html', context)
+    plain_message = render_to_string('user/email/account_invite_message.txt', context)
+
+    try:
+        send_mail(
+            subject=subject,
+            message=plain_message,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[user.email],
+            html_message=html_message,
+            fail_silently=False,
+        )
+        logger.info('Account invite email sent to %s', user.email)
+        return True
+    except Exception as exc:
+        logger.error('Failed to send account invite email to %s: %s', user.email, exc, exc_info=True)
+        return False

--- a/app/user/forms.py
+++ b/app/user/forms.py
@@ -33,6 +33,51 @@ class CustomUserCreationForm(UserCreationForm):
         return user
 
 
+class AdminUserCreateForm(forms.ModelForm):
+    """Passwordless form for administrators creating user accounts."""
+
+    role = forms.ModelChoiceField(
+        queryset=Role.objects.filter(is_active=True),
+        required=False,
+        empty_label="No role assigned",
+    )
+
+    class Meta:
+        model = CustomUser
+        fields = ('username', 'email', 'first_name', 'last_name', 'role')
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['email'].required = True
+        for field_name, field in self.fields.items():
+            if field_name == 'role':
+                field.widget.attrs.update({'class': 'form-select'})
+            else:
+                field.widget.attrs.update({'class': 'form-control'})
+
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        user.set_unusable_password()
+        user.is_approved = True
+        if commit:
+            user.save()
+            self._ensure_verified_email_address(user)
+        return user
+
+    def _ensure_verified_email_address(self, user):
+        from allauth.account.models import EmailAddress
+
+        email_address, created = EmailAddress.objects.get_or_create(
+            user=user,
+            email=user.email,
+            defaults={'verified': True, 'primary': True},
+        )
+        if not created:
+            email_address.verified = True
+            email_address.primary = True
+            email_address.save(update_fields=['verified', 'primary'])
+
+
 class CustomUserEditForm(UserChangeForm):
     role = forms.ModelChoiceField(
         queryset=Role.objects.filter(is_active=True),

--- a/app/user/tests.py
+++ b/app/user/tests.py
@@ -10,7 +10,7 @@ import json
 
 from .models import Role, APIKey
 from .forms import (
-    CustomUserCreationForm, CustomUserEditForm, UserProfileForm, 
+    CustomUserCreationForm, AdminUserCreateForm, CustomUserEditForm, UserProfileForm,
     UserSettingsForm, UserNotificationForm, DataExportForm, RoleForm, RoleFilterForm,
     APIKeyCreateForm, APIKeyRevokeForm
 )
@@ -682,6 +682,30 @@ class UserFormTests(TestCase):
         user = form.save()
         self.assertTrue(user.is_approved)  # Auto-approved by admin
     
+    def test_admin_user_create_form_valid_data(self):
+        """Test AdminUserCreateForm creates an approved user without a password."""
+        form_data = {
+            'username': 'inviteduser',
+            'email': 'inviteduser@example.com',
+            'first_name': 'Invited',
+            'last_name': 'User',
+            'role': self.role.id,
+        }
+
+        form = AdminUserCreateForm(data=form_data)
+        self.assertTrue(form.is_valid())
+
+        user = form.save()
+        self.assertEqual(user.username, 'inviteduser')
+        self.assertEqual(user.email, 'inviteduser@example.com')
+        self.assertTrue(user.is_approved)
+        self.assertFalse(user.has_usable_password())
+
+        from allauth.account.models import EmailAddress
+        email_address = EmailAddress.objects.get(user=user, email=user.email)
+        self.assertTrue(email_address.verified)
+        self.assertTrue(email_address.primary)
+
     def test_custom_user_creation_form_invalid_data(self):
         """Test CustomUserCreationForm with invalid data"""
         form_data = {
@@ -1261,27 +1285,36 @@ class UserViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'user/user_form.html')
     
+    @override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
     def test_user_create_view_post_valid_data(self):
         """Test POST request to user create view with valid data"""
+        from django.core import mail
+
         self.client.login(username='admin', password='adminpass123')
-        
+
         form_data = {
             'username': 'newuser',
             'email': 'newuser@example.com',
             'first_name': 'New',
             'last_name': 'User',
-            'password1': 'complexpass123',
-            'password2': 'complexpass123',
             'role': self.role.id
         }
-        
+
         response = self.client.post(reverse('user-create'), form_data)
         self.assertEqual(response.status_code, 302)  # Redirect
-        
+
         # Check user was created and approved
         self.assertTrue(self.User.objects.filter(username='newuser').exists())
         user = self.User.objects.get(username='newuser')
         self.assertTrue(user.is_approved)  # Auto-approved by admin
+        self.assertFalse(user.has_usable_password())
+
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertIn('newuser@example.com', message.to)
+        self.assertIn('newuser', message.body)
+        self.assertIn('newuser@example.com', message.body)
+        self.assertIn('/password/reset/key/', message.body)
     
     def test_user_edit_view_requires_permission(self):
         """Test that user edit view requires admin permission"""
@@ -1595,18 +1628,18 @@ class UserIntegrationTests(TestCase):
             'email': 'newuser@example.com',
             'first_name': 'New',
             'last_name': 'User',
-            'password1': 'complexpass123',
-            'password2': 'complexpass123',
             'role': self.role.id
         }
         
-        response = self.client.post(reverse('user-create'), create_data)
+        with override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend'):
+            response = self.client.post(reverse('user-create'), create_data)
         self.assertEqual(response.status_code, 302)  # Redirect
         
         # Check user was created and approved
         self.assertTrue(self.User.objects.filter(username='newuser').exists())
         new_user = self.User.objects.get(username='newuser')
         self.assertTrue(new_user.is_approved)
+        self.assertFalse(new_user.has_usable_password())
         
         # Step 4: Admin edits user
         edit_data = {

--- a/app/user/views.py
+++ b/app/user/views.py
@@ -18,10 +18,11 @@ from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 
 from .forms import (
-    CustomUserCreationForm, CustomUserEditForm, RoleForm, RoleFilterForm, UserSettingsForm,
-    UserNotificationForm, UserProfileForm, DataExportForm, APIKeyCreateForm, APIKeyRevokeForm,
-    AdminSetPasswordForm,
+    CustomUserCreationForm, CustomUserEditForm, AdminUserCreateForm, RoleForm, RoleFilterForm,
+    UserSettingsForm, UserNotificationForm, UserProfileForm, DataExportForm, APIKeyCreateForm,
+    APIKeyRevokeForm, AdminSetPasswordForm,
 )
+from .email_utils import send_account_invite_email
 from .models import Role, APIKey
 
 CustomUser = get_user_model()
@@ -550,7 +551,7 @@ class UsersListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
 
 class UserCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
     model = get_user_model()
-    form_class = CustomUserCreationForm
+    form_class = AdminUserCreateForm
     template_name = 'user/user_form.html'
     success_url = reverse_lazy('user-list')
 
@@ -561,19 +562,25 @@ class UserCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
             (self.request.user.role and self.request.user.role.name == 'Administrator')
         )
 
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        # Since this is an admin view, mark as created by admin
-        kwargs['created_by_admin'] = True
-        return kwargs
-
     def form_valid(self, form):
-        user = form.save()
-        messages.success(
-            self.request, 
-            f'User {user.username} has been created and approved successfully.'
-        )
-        return super().form_valid(form)
+        response = super().form_valid(form)
+        email_sent = send_account_invite_email(self.object, request=self.request)
+        if email_sent:
+            messages.success(
+                self.request,
+                _('User %(username)s has been created and an invitation email has been sent.') % {
+                    'username': self.object.username,
+                },
+            )
+        else:
+            messages.warning(
+                self.request,
+                _('User %(username)s has been created, but the invitation email could not be sent. '
+                  'Please ask the user to use password reset or resend the invite manually.') % {
+                    'username': self.object.username,
+                },
+            )
+        return response
 
     def form_invalid(self, form):
         messages.error(self.request, 'Please correct the errors below.')


### PR DESCRIPTION
- Introduced a new AdminUserCreateForm for administrators to create user accounts without requiring a password.
- Implemented email notifications for newly created users, including a link to set their password.
- Updated user creation view to send an invitation email upon successful account creation.
- Added corresponding email templates for both HTML and plain text formats.
- Enhanced tests to verify the functionality of the new user creation and email invitation process.