### PR TITLE
Implement chunked file upload functionality for dataset versions

### DIFF
--- a/app/datasets/chunk_uploads.py
+++ b/app/datasets/chunk_uploads.py
@@ -1,0 +1,196 @@
+import json
+import os
+import re
+import shutil
+from datetime import timedelta
+from pathlib import Path
+
+from django.conf import settings
+from django.core.files import File
+from django.utils import timezone
+
+CHUNK_ROOT = 'tmp/chunks'
+CHUNK_MAX_AGE_HOURS = 24
+UPLOAD_ID_PATTERN = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', re.I)
+
+
+def chunk_base_dir(user_id, upload_id):
+    return Path(settings.MEDIA_ROOT) / CHUNK_ROOT / str(user_id) / str(upload_id)
+
+
+def meta_path(user_id, upload_id):
+    return chunk_base_dir(user_id, upload_id) / 'meta.json'
+
+
+def assembled_file_path(user_id, upload_id, file_index):
+    return chunk_base_dir(user_id, upload_id) / str(file_index)
+
+
+def validate_upload_id(upload_id):
+    if not upload_id or not UPLOAD_ID_PATTERN.match(str(upload_id)):
+        raise ValueError('Invalid upload_id.')
+    return str(upload_id)
+
+
+def cleanup_old_chunk_dirs():
+    """Remove chunk upload directories older than CHUNK_MAX_AGE_HOURS."""
+    root = Path(settings.MEDIA_ROOT) / CHUNK_ROOT
+    if not root.exists():
+        return
+
+    cutoff = timezone.now() - timedelta(hours=CHUNK_MAX_AGE_HOURS)
+    for user_dir in root.iterdir():
+        if not user_dir.is_dir():
+            continue
+        for upload_dir in user_dir.iterdir():
+            if not upload_dir.is_dir():
+                continue
+            try:
+                from datetime import datetime
+
+                mtime = datetime.fromtimestamp(
+                    upload_dir.stat().st_mtime,
+                    tz=timezone.get_current_timezone(),
+                )
+            except OSError:
+                continue
+            if mtime < cutoff:
+                shutil.rmtree(upload_dir, ignore_errors=True)
+
+
+def _load_meta(user_id, upload_id):
+    path = meta_path(user_id, upload_id)
+    if not path.exists():
+        return {'files': {}}
+    with path.open('r', encoding='utf-8') as handle:
+        return json.load(handle)
+
+
+def _save_meta(user_id, upload_id, meta):
+    base = chunk_base_dir(user_id, upload_id)
+    base.mkdir(parents=True, exist_ok=True)
+    with meta_path(user_id, upload_id).open('w', encoding='utf-8') as handle:
+        json.dump(meta, handle)
+
+
+def append_chunk(user, upload_id, file_index, chunk_index, total_chunks, filename, chunk_file):
+    """Append one chunk to an in-progress upload. Chunks must arrive in order."""
+    upload_id = validate_upload_id(upload_id)
+    cleanup_old_chunk_dirs()
+
+    file_index = int(file_index)
+    chunk_index = int(chunk_index)
+    total_chunks = int(total_chunks)
+
+    if total_chunks < 1:
+        raise ValueError('total_chunks must be at least 1.')
+    if chunk_index < 0 or chunk_index >= total_chunks:
+        raise ValueError('chunk_index out of range.')
+
+    chunk_bytes = chunk_file.read()
+    chunk_size = len(chunk_bytes)
+    if chunk_size > settings.MAX_DATASET_UPLOAD_SIZE:
+        raise ValueError('Chunk exceeds maximum upload size.')
+
+    meta = _load_meta(user.pk, upload_id)
+    files_meta = meta.setdefault('files', {})
+    file_key = str(file_index)
+    file_meta = files_meta.get(file_key, {
+        'filename': filename,
+        'total_chunks': total_chunks,
+        'next_chunk_index': 0,
+        'size': 0,
+    })
+
+    if file_meta['total_chunks'] != total_chunks:
+        raise ValueError('total_chunks mismatch for file.')
+    if file_meta['filename'] != filename:
+        raise ValueError('filename mismatch for file.')
+    if file_meta['next_chunk_index'] != chunk_index:
+        raise ValueError(
+            f'Expected chunk {file_meta["next_chunk_index"]}, received {chunk_index}.'
+        )
+
+    dest_path = assembled_file_path(user.pk, upload_id, file_index)
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    mode = 'ab' if dest_path.exists() else 'wb'
+    with dest_path.open(mode) as handle:
+        handle.write(chunk_bytes)
+
+    file_meta['size'] += chunk_size
+    file_meta['next_chunk_index'] = chunk_index + 1
+    files_meta[file_key] = file_meta
+    meta['files'] = files_meta
+    _save_meta(user.pk, upload_id, meta)
+
+    return {
+        'upload_id': upload_id,
+        'file_index': file_index,
+        'chunk_index': chunk_index,
+        'received_chunks': file_meta['next_chunk_index'],
+        'total_chunks': total_chunks,
+        'assembled_size': file_meta['size'],
+    }
+
+
+def load_assembled_upload_files(user, upload_id, expected_files):
+    """
+    Validate assembled chunk files and return Django File objects ready for saving.
+
+    expected_files: list of dicts with file_index, filename, file_size (int).
+    """
+    upload_id = validate_upload_id(upload_id)
+    if not expected_files:
+        raise ValueError('No chunked files specified.')
+
+    meta = _load_meta(user.pk, upload_id)
+    files_meta = meta.get('files', {})
+    total_size = 0
+    opened_files = []
+
+    for entry in expected_files:
+        file_index = int(entry['file_index'])
+        filename = entry['filename']
+        expected_size = int(entry['file_size'])
+        file_key = str(file_index)
+
+        if file_key not in files_meta:
+            raise ValueError(f'File index {file_index} was not uploaded.')
+
+        file_meta = files_meta[file_key]
+        if file_meta['next_chunk_index'] != file_meta['total_chunks']:
+            raise ValueError(f'File "{filename}" upload is incomplete.')
+        if file_meta['filename'] != filename:
+            raise ValueError(f'Filename mismatch for file index {file_index}.')
+        if file_meta['size'] != expected_size:
+            raise ValueError(
+                f'Size mismatch for "{filename}": expected {expected_size}, '
+                f'got {file_meta["size"]}.'
+            )
+
+        path = assembled_file_path(user.pk, upload_id, file_index)
+        if not path.exists():
+            raise ValueError(f'Assembled file missing for index {file_index}.')
+
+        if expected_size > settings.MAX_DATASET_UPLOAD_SIZE:
+            raise ValueError(f'File "{filename}" exceeds maximum upload size.')
+
+        total_size += expected_size
+        django_file = File(path.open('rb'), name=os.path.basename(filename))
+        django_file.size = expected_size
+        opened_files.append(django_file)
+
+    if total_size > settings.MAX_DATASET_UPLOAD_SIZE:
+        for handle in opened_files:
+            handle.close()
+        raise ValueError('Total upload size exceeds the maximum allowed limit.')
+
+    return opened_files, total_size
+
+
+def remove_chunk_upload(user_id, upload_id):
+    """Delete temporary chunk directory after successful version creation."""
+    upload_id = validate_upload_id(upload_id)
+    base = chunk_base_dir(user_id, upload_id)
+    if base.exists():
+        shutil.rmtree(base, ignore_errors=True)

--- a/app/datasets/forms.py
+++ b/app/datasets/forms.py
@@ -1,3 +1,5 @@
+import json
+
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -281,6 +283,7 @@ class DatasetVersionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.dataset = kwargs.pop('dataset', None)
+        self.user = kwargs.pop('user', None)
         super().__init__(*args, **kwargs)
         
         # Add help text for fields
@@ -324,38 +327,66 @@ class DatasetVersionForm(forms.ModelForm):
         
         # Validate based on input method
         if input_method == 'upload':
-            if not uploaded_files:
+            upload_id = self.data.get('upload_id')
+            chunked_files_raw = self.data.get('chunked_files')
+
+            if upload_id and chunked_files_raw:
+                from .chunk_uploads import load_assembled_upload_files
+
+                if not self.user or not self.user.is_authenticated:
+                    raise forms.ValidationError('Authentication required for chunked uploads.')
+
+                try:
+                    expected_files = json.loads(chunked_files_raw)
+                except (json.JSONDecodeError, TypeError):
+                    raise forms.ValidationError('Invalid chunked file metadata.')
+
+                if not isinstance(expected_files, list) or not expected_files:
+                    raise forms.ValidationError('No chunked files specified.')
+
+                try:
+                    uploaded_files, total_upload_size = load_assembled_upload_files(
+                        self.user,
+                        upload_id,
+                        expected_files,
+                    )
+                except ValueError as exc:
+                    raise forms.ValidationError(str(exc)) from exc
+
+                cleaned_data['upload_id'] = upload_id
+                self.instance.file_size = total_upload_size
+            elif not uploaded_files:
                 self.add_error('files', 'Please upload at least one file when using the upload method.')
                 raise forms.ValidationError('Please upload at least one file when using the upload method.')
+            else:
+                max_upload_size = settings.MAX_DATASET_UPLOAD_SIZE
+                max_upload_gb = max_upload_size // (1024 * 1024 * 1024)
+
+                for upload in uploaded_files:
+                    if upload.size > max_upload_size:
+                        size_gb = upload.size / (1024 * 1024 * 1024)
+                        self.add_error(
+                            'files',
+                            f'File "{upload.name}" ({size_gb:.2f} GB) exceeds the {max_upload_gb}GB size limit.',
+                        )
+                        raise forms.ValidationError(f'Each uploaded file must be {max_upload_gb}GB or smaller.')
+
+                    total_upload_size += upload.size
+
+                if total_upload_size > max_upload_size:
+                    total_gb = total_upload_size / (1024 * 1024 * 1024)
+                    self.add_error(
+                        'files',
+                        f'Total upload size ({total_gb:.2f} GB) exceeds the {max_upload_gb}GB limit.',
+                    )
+                    raise forms.ValidationError(f'Total upload size must be {max_upload_gb}GB or smaller.')
+
+                self.instance.file_size = total_upload_size
+
             if file_url:
                 raise forms.ValidationError('Please do not provide a URL when uploading a file.')
             if file_size_text:
                 raise forms.ValidationError('File size will be calculated automatically when uploading.')
-            
-            max_upload_size = settings.MAX_DATASET_UPLOAD_SIZE
-            max_upload_gb = max_upload_size // (1024 * 1024 * 1024)
-
-            for upload in uploaded_files:
-                if upload.size > max_upload_size:
-                    size_gb = upload.size / (1024 * 1024 * 1024)
-                    self.add_error(
-                        'files',
-                        f'File "{upload.name}" ({size_gb:.2f} GB) exceeds the {max_upload_gb}GB size limit.',
-                    )
-                    raise forms.ValidationError(f'Each uploaded file must be {max_upload_gb}GB or smaller.')
-
-                total_upload_size += upload.size
-
-            if total_upload_size > max_upload_size:
-                total_gb = total_upload_size / (1024 * 1024 * 1024)
-                self.add_error(
-                    'files',
-                    f'Total upload size ({total_gb:.2f} GB) exceeds the {max_upload_gb}GB limit.',
-                )
-                raise forms.ValidationError(f'Total upload size must be {max_upload_gb}GB or smaller.')
-
-            # Update file_size field with total upload size
-            self.instance.file_size = total_upload_size
             
         elif input_method == 'url':
             # Either URL or description must be provided (or both)

--- a/app/datasets/tests.py
+++ b/app/datasets/tests.py
@@ -10,6 +10,7 @@ from django.utils.datastructures import MultiValueDict
 from unittest.mock import patch, MagicMock
 from datetime import timedelta
 from tempfile import TemporaryDirectory
+import json
 import uuid
 
 from .models import (
@@ -531,6 +532,143 @@ class DatasetVersionFormTests(TestCase):
         accept_attr = form.fields['files'].widget.attrs.get('accept', '')
         self.assertIn('.dta', accept_attr, '.dta should be in accept attribute')
         self.assertIn('.rds', accept_attr, '.rds should be in accept attribute')
+
+
+class DatasetVersionChunkUploadTests(TestCase):
+    """Tests for chunked dataset version uploads."""
+
+    def setUp(self):
+        self.temp_media = TemporaryDirectory()
+        self.override_media = override_settings(MEDIA_ROOT=self.temp_media.name)
+        self.override_media.enable()
+
+        self.user = User.objects.create_user(
+            username='chunkowner',
+            email='chunkowner@example.com',
+            password='testpass123',
+        )
+        self.other_user = User.objects.create_user(
+            username='chunkother',
+            email='chunkother@example.com',
+            password='testpass123',
+        )
+        self.dataset = Dataset.objects.create(
+            title='Chunk Dataset',
+            description='Dataset for chunk upload tests',
+            owner=self.user,
+        )
+        self.upload_id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+        self.chunk_url = reverse(
+            'datasets:dataset_version_upload_chunk',
+            args=[self.dataset.pk],
+        )
+        self.create_url = reverse(
+            'datasets:dataset_version_create',
+            args=[self.dataset.pk],
+        )
+        self.client = Client()
+
+    def tearDown(self):
+        self.override_media.disable()
+        self.temp_media.cleanup()
+
+    def _post_chunk(self, user, file_index, chunk_index, total_chunks, filename, content):
+        self.client.force_login(user)
+        return self.client.post(
+            self.chunk_url,
+            {
+                'upload_id': self.upload_id,
+                'file_index': file_index,
+                'chunk_index': chunk_index,
+                'total_chunks': total_chunks,
+                'filename': filename,
+                'file': SimpleUploadedFile(filename, content),
+            },
+        )
+
+    def test_chunk_upload_and_create_version(self):
+        """Owner can upload chunks and create a version from assembled files."""
+        from .chunk_uploads import chunk_base_dir
+
+        content = b'hello chunk world'
+        mid = len(content) // 2
+
+        response1 = self._post_chunk(self.user, 0, 0, 2, 'data.txt', content[:mid])
+        self.assertEqual(response1.status_code, 200)
+        self.assertTrue(response1.json()['success'])
+
+        response2 = self._post_chunk(self.user, 0, 1, 2, 'data.txt', content[mid:])
+        self.assertEqual(response2.status_code, 200)
+        self.assertTrue(response2.json()['success'])
+
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.create_url,
+            {
+                'version_number': '2.0',
+                'description': 'Chunked upload',
+                'input_method': 'upload',
+                'file_url': '',
+                'file_url_description': '',
+                'file_size_text': '',
+                'upload_id': self.upload_id,
+                'chunked_files': json.dumps([
+                    {
+                        'file_index': 0,
+                        'filename': 'data.txt',
+                        'file_size': len(content),
+                    },
+                ]),
+            },
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['success'])
+
+        version = DatasetVersion.objects.get(dataset=self.dataset, version_number='2.0')
+        version_files = DatasetVersionFile.objects.filter(version=version)
+        self.assertEqual(version_files.count(), 1)
+        self.assertEqual(version_files.first().original_name, 'data.txt')
+        self.assertEqual(version_files.first().file_size, len(content))
+        self.assertFalse(chunk_base_dir(self.user.pk, self.upload_id).exists())
+
+    def test_chunk_upload_forbidden_for_non_contributor(self):
+        """Non-contributors cannot upload chunks."""
+        self.client.force_login(self.other_user)
+        response = self.client.post(
+            self.chunk_url,
+            {
+                'upload_id': self.upload_id,
+                'file_index': 0,
+                'chunk_index': 0,
+                'total_chunks': 1,
+                'filename': 'data.txt',
+                'file': SimpleUploadedFile('data.txt', b'data'),
+            },
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(response.json()['success'])
+
+    def test_chunk_upload_rejects_out_of_order_chunk(self):
+        """Chunks must arrive in sequential order."""
+        content = b'abcdefghij'
+        self._post_chunk(self.user, 0, 0, 2, 'data.txt', content[:5])
+
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.chunk_url,
+            {
+                'upload_id': self.upload_id,
+                'file_index': 0,
+                'chunk_index': 0,
+                'total_chunks': 2,
+                'filename': 'data.txt',
+                'file': SimpleUploadedFile('data.txt', content[5:]),
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Expected chunk', response.json()['error'])
 
 
 class DatasetModelTests(TestCase):

--- a/app/datasets/urls.py
+++ b/app/datasets/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path('<uuid:pk>/delete/', views.DatasetDeleteView.as_view(), name='dataset_delete'),
     path('<uuid:pk>/download/', views.dataset_download, name='dataset_download'),
     path('<uuid:pk>/assign-project/', views.assign_dataset_to_project, name='assign_to_project'),
+    path('<uuid:dataset_pk>/version/upload-chunk/', views.upload_dataset_version_chunk, name='dataset_version_upload_chunk'),
     path('<uuid:dataset_pk>/version/create/', views.DatasetVersionCreateView.as_view(), name='dataset_version_create'),
     
     # Analysis/DataViz views

--- a/app/datasets/views.py
+++ b/app/datasets/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import redirect_to_login
 from django.contrib import messages
-from django.http import HttpResponse, Http404, FileResponse
+from django.http import HttpResponse, Http404, FileResponse, JsonResponse
 from django.views.generic import ListView, DetailView, CreateView, UpdateView, DeleteView
 from django.urls import reverse_lazy, reverse
 from django.db.models import Q, Count
@@ -24,6 +24,58 @@ from .models import (
     DatasetAnalysis,
 )
 from .forms import DatasetForm, DatasetFilterForm, DatasetVersionForm, DatasetCategoryForm, DatasetCategoryFilterForm, CommentForm, CommentEditForm, PublisherForm, PublisherFilterForm, DatasetProjectAssignmentForm, DatasetAnalysisForm
+from .chunk_uploads import append_chunk, remove_chunk_upload
+
+
+def user_can_manage_dataset_versions(user, dataset):
+    """Return True if the user may add versions to the dataset."""
+    return (
+        user == dataset.owner
+        or user in dataset.contributors.all()
+        or user.is_superuser
+    )
+
+
+@login_required
+def upload_dataset_version_chunk(request, dataset_pk):
+    """Append one chunk to a staged dataset version upload."""
+    if request.method != 'POST':
+        return JsonResponse({'success': False, 'error': 'POST required.'}, status=405)
+
+    dataset = get_object_or_404(Dataset, pk=dataset_pk)
+    if not user_can_manage_dataset_versions(request.user, dataset):
+        return JsonResponse({'success': False, 'error': 'Permission denied.'}, status=403)
+
+    upload_id = request.POST.get('upload_id')
+    file_index = request.POST.get('file_index')
+    chunk_index = request.POST.get('chunk_index')
+    total_chunks = request.POST.get('total_chunks')
+    filename = request.POST.get('filename')
+    chunk_file = request.FILES.get('file')
+
+    if not all([
+        upload_id,
+        file_index is not None,
+        chunk_index is not None,
+        total_chunks,
+        filename,
+        chunk_file,
+    ]):
+        return JsonResponse({'success': False, 'error': 'Missing required fields.'}, status=400)
+
+    try:
+        result = append_chunk(
+            request.user,
+            upload_id,
+            file_index,
+            chunk_index,
+            total_chunks,
+            filename,
+            chunk_file,
+        )
+        return JsonResponse({'success': True, **result})
+    except ValueError as exc:
+        return JsonResponse({'success': False, 'error': str(exc)}, status=400)
 
 
 class AdministratorOnlyMixin(UserPassesTestMixin):
@@ -411,6 +463,7 @@ class DatasetVersionCreateView(LoginRequiredMixin, CreateView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs['dataset'] = self.dataset
+        kwargs['user'] = self.request.user
         return kwargs
 
     def form_valid(self, form):
@@ -421,6 +474,7 @@ class DatasetVersionCreateView(LoginRequiredMixin, CreateView):
             input_method = form.cleaned_data.get('input_method')
             uploaded_files = form.cleaned_data.get('uploaded_files', [])
             total_upload_size = form.cleaned_data.get('uploaded_files_total_size', 0)
+            upload_id = form.cleaned_data.get('upload_id')
 
             logger.info(f'Creating dataset version for dataset {self.dataset.pk}, user: {self.request.user.username}, '
                        f'method: {input_method}, files: {len(uploaded_files)}, total_size: {total_upload_size}')
@@ -463,6 +517,9 @@ class DatasetVersionCreateView(LoginRequiredMixin, CreateView):
                         except Exception as e:
                             logger.error(f'Error saving file {upload.name}: {str(e)}', exc_info=True)
                             raise
+
+            if upload_id:
+                remove_chunk_upload(self.request.user.pk, upload_id)
 
             # Send notification about new version
             try:
@@ -545,19 +602,6 @@ class DatasetVersionCreateView(LoginRequiredMixin, CreateView):
 
     def get_success_url(self):
         return reverse('datasets:dataset_detail', kwargs={'pk': self.dataset.pk})
-    
-    def dispatch(self, request, *args, **kwargs):
-        # Get the dataset and check permissions
-        self.dataset = get_object_or_404(Dataset, pk=kwargs['dataset_pk'])
-        
-        # Check if user can add versions (owner, contributor, or superuser)
-        if not (request.user == self.dataset.owner or 
-                request.user in self.dataset.contributors.all() or 
-                request.user.is_superuser):
-            messages.error(request, 'You do not have permission to add versions to this dataset.')
-            return redirect('datasets:dataset_detail', pk=self.dataset.pk)
-        
-        return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         from django.conf import settings
@@ -565,6 +609,10 @@ class DatasetVersionCreateView(LoginRequiredMixin, CreateView):
         context = super().get_context_data(**kwargs)
         context['dataset'] = self.dataset
         context['max_dataset_upload_size'] = settings.MAX_DATASET_UPLOAD_SIZE
+        context['chunk_upload_url'] = reverse(
+            'datasets:dataset_version_upload_chunk',
+            kwargs={'dataset_pk': self.dataset.pk},
+        )
         return context
 
 

--- a/app/templates/datasets/dataset_version_form.html
+++ b/app/templates/datasets/dataset_version_form.html
@@ -299,6 +299,9 @@ let isUploading = false;
 let uploadPromises = [];
 const MAX_DATASET_UPLOAD_SIZE = {{ max_dataset_upload_size }};
 const MAX_DATASET_UPLOAD_SIZE_GB = Math.round(MAX_DATASET_UPLOAD_SIZE / (1024 * 1024 * 1024));
+const CHUNK_UPLOAD_URL = '{{ chunk_upload_url|escapejs }}';
+const CHUNK_SIZE = 8 * 1024 * 1024;
+const CHUNKED_UPLOAD_THRESHOLD = 32 * 1024 * 1024;
 
 function validateUploadSize(files) {
     const fileList = Array.from(files || []);
@@ -602,6 +605,252 @@ function handleFileSelection() {
     });
 }
 
+function generateUploadId() {
+    if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+        return window.crypto.randomUUID();
+    }
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        const r = Math.random() * 16 | 0;
+        const v = c === 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+}
+
+async function postChunkWithRetry(formData, retries = 1) {
+    let lastError = null;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+            const response = await fetch(CHUNK_UPLOAD_URL, {
+                method: 'POST',
+                body: formData,
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+                credentials: 'same-origin',
+            });
+            let data = {};
+            try {
+                data = await response.json();
+            } catch (parseError) {
+                throw new Error(`{% trans "Chunk upload failed" %} (HTTP ${response.status})`);
+            }
+            if (!response.ok || !data.success) {
+                throw new Error(data.error || `{% trans "Chunk upload failed" %} (HTTP ${response.status})`);
+            }
+            return data;
+        } catch (error) {
+            lastError = error;
+            if (attempt >= retries) {
+                throw lastError;
+            }
+        }
+    }
+    throw lastError || new Error('{% trans "Chunk upload failed" %}');
+}
+
+async function uploadFilesInChunks(files, uploadId, onProgress) {
+    let bytesSent = 0;
+    const totalSize = files.reduce((sum, file) => sum + file.size, 0);
+    const chunkedFilesMeta = [];
+    const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+
+    for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
+        const file = files[fileIndex];
+        const totalChunks = Math.max(1, Math.ceil(file.size / CHUNK_SIZE));
+
+        for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+            const start = chunkIndex * CHUNK_SIZE;
+            const end = Math.min(start + CHUNK_SIZE, file.size);
+            const chunk = file.slice(start, end);
+
+            const formData = new FormData();
+            formData.append('upload_id', uploadId);
+            formData.append('file_index', fileIndex);
+            formData.append('chunk_index', chunkIndex);
+            formData.append('total_chunks', totalChunks);
+            formData.append('filename', file.name);
+            formData.append('file', chunk, file.name);
+            formData.append('csrfmiddlewaretoken', csrfToken);
+
+            await postChunkWithRetry(formData, 1);
+            bytesSent += chunk.size;
+            if (onProgress) {
+                onProgress(bytesSent, totalSize);
+            }
+        }
+
+        chunkedFilesMeta.push({
+            file_index: fileIndex,
+            filename: file.name,
+            file_size: file.size,
+        });
+    }
+
+    return chunkedFilesMeta;
+}
+
+function handleUploadXhrResponse(xhr, submitBtn, submitBtnText, submitBtnSpinner, cancelBtn) {
+    console.log('Upload response status:', xhr.status);
+    console.log('Upload response headers:', xhr.getAllResponseHeaders());
+    console.log('Upload response text (first 1000 chars):', xhr.responseText ? xhr.responseText.substring(0, 1000) : '(empty)');
+
+    if (xhr.status === 200) {
+        try {
+            const response = JSON.parse(xhr.responseText);
+            console.log('Parsed JSON response:', response);
+
+            if (response.success && response.redirect_url) {
+                window.location.href = response.redirect_url;
+            } else if (response.error) {
+                let errorMessage = response.error;
+
+                if (response.errors) {
+                    errorMessage += '\n\nField errors:';
+                    for (const [field, errors] of Object.entries(response.errors)) {
+                        errorMessage += `\n- ${field}: ${Array.isArray(errors) ? errors.join(', ') : errors}`;
+                    }
+                }
+
+                if (response.non_field_errors && response.non_field_errors.length > 0) {
+                    errorMessage += '\n\nGeneral errors: ' + response.non_field_errors.join(', ');
+                }
+
+                if (response.error_details) {
+                    console.error('Detailed error:', response.error_details);
+                    errorMessage += '\n\n[Check browser console for full details]';
+                }
+
+                updateUploadStatusText('{% trans "Upload failed" %}: ' + response.error);
+                alert(errorMessage);
+                reEnableUploadForm(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
+            } else {
+                console.warn('Unexpected response format:', response);
+                updateUploadStatusText('{% trans "Unexpected response from server" %}');
+                alert('{% trans "Unexpected response from server. Please check the console for details." %}');
+                reEnableUploadForm(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
+            }
+        } catch (e) {
+            console.log('Response is not JSON, parsing as HTML. Error:', e);
+            if (xhr.responseURL) {
+                window.location.href = xhr.responseURL;
+            } else {
+                const parser = new DOMParser();
+                const doc = parser.parseFromString(xhr.responseText, 'text/html');
+                const errorElements = doc.querySelectorAll('.alert-danger, .error, .invalid-feedback, .non-field-errors');
+                let errorText = '{% trans "An error occurred. Server returned HTML response." %}';
+                if (errorElements.length > 0) {
+                    errorText += '\n\n' + Array.from(errorElements).map(el => el.textContent.trim()).filter(text => text.length > 0).join('\n');
+                }
+                updateUploadStatusText('{% trans "Upload failed" %}');
+                alert(errorText + '\n\n[Full response logged to console]');
+                console.error('HTML response:', xhr.responseText);
+                reEnableUploadForm(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
+            }
+        }
+    } else if (xhr.status === 302) {
+        const location = xhr.getResponseHeader('Location');
+        if (location) {
+            window.location.href = location;
+        } else if (xhr.responseURL) {
+            window.location.href = xhr.responseURL;
+        } else {
+            window.location.href = window.location.href;
+        }
+    } else if (xhr.status === 413) {
+        let errorMessage = '{% trans "Upload failed: File is too large" %}';
+        let details = '';
+        const fileInput = document.getElementById('{{ form.files.id_for_label }}');
+        if (fileInput && fileInput.files) {
+            let totalSize = 0;
+            Array.from(fileInput.files).forEach(file => {
+                totalSize += file.size;
+            });
+            const totalSizeMB = (totalSize / (1024 * 1024)).toFixed(2);
+            const totalSizeGB = (totalSize / (1024 * 1024 * 1024)).toFixed(2);
+            details = `\n\n{% trans "Total file size" %}: ${totalSizeGB} GB (${totalSizeMB} MB)`;
+            details += `\n{% trans "Maximum allowed size" %}: ${MAX_DATASET_UPLOAD_SIZE_GB} GB`;
+        }
+
+        errorMessage += details;
+        errorMessage += '\n\n{% trans "Please either:" %}';
+        errorMessage += '\n1. {% trans "Compress your files before uploading" %}';
+        errorMessage += '\n2. {% trans "Split into smaller files" %}';
+        errorMessage += '\n3. {% trans "Contact administrator if you need to upload larger files" %}';
+
+        updateUploadStatusText('{% trans "Upload failed: File too large" %}');
+        alert(errorMessage);
+        console.error('413 Request Entity Too Large - File size limit exceeded');
+        console.error('Response:', xhr.responseText);
+        reEnableUploadForm(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
+    } else if (xhr.status === 502 || xhr.status === 504) {
+        console.error(`${xhr.status} gateway error during upload`);
+        console.error('Response:', xhr.responseText);
+        showServerTimeoutUploadError(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
+    } else {
+        let errorMessage = `{% trans "Upload failed" %} (HTTP ${xhr.status} ${xhr.statusText})`;
+
+        try {
+            const response = JSON.parse(xhr.responseText);
+            console.error('Error response:', response);
+            if (response.error) {
+                errorMessage = response.error;
+            }
+            if (response.errors) {
+                errorMessage += '\n\nField errors:';
+                for (const [field, errors] of Object.entries(response.errors)) {
+                    errorMessage += `\n- ${field}: ${Array.isArray(errors) ? errors.join(', ') : errors}`;
+                }
+            }
+            if (response.error_details) {
+                console.error('Error details:', response.error_details);
+                errorMessage += '\n\n[Check browser console for full details]';
+            }
+        } catch (e) {
+            errorMessage += '\n\nResponse: ' + (xhr.responseText ? xhr.responseText.substring(0, 500) : '(empty)');
+            console.error('Error response text:', xhr.responseText);
+        }
+
+        updateUploadStatusText(errorMessage);
+        alert(errorMessage + '\n\n{% trans "Please check the browser console for more details." %}');
+        reEnableUploadForm(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
+    }
+}
+
+function submitVersionCreateRequest(formData, submitBtn, submitBtnText, submitBtnSpinner, cancelBtn) {
+    const form = document.querySelector('form[method="post"]');
+    const xhr = new XMLHttpRequest();
+
+    xhr.addEventListener('load', () => {
+        handleUploadXhrResponse(xhr, submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
+    });
+
+    xhr.addEventListener('error', () => {
+        console.error('Network error during upload');
+        console.error('Status:', xhr.status);
+        console.error('Status text:', xhr.statusText);
+        console.error('Response:', xhr.responseText);
+        console.error('Ready state:', xhr.readyState);
+
+        if (xhr.readyState === 4) {
+            showServerTimeoutUploadError(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
+            return;
+        }
+
+        updateUploadStatusText('{% trans "Network error during upload" %}');
+        alert('{% trans "Network error during upload. Please check your connection and try again." %}\n\n{% trans "Check the browser console (F12) for more details." %}');
+        reEnableUploadForm(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
+    });
+
+    xhr.addEventListener('abort', () => {
+        updateUploadStatusText('{% trans "Upload cancelled" %}');
+        reEnableUploadForm(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
+    });
+
+    xhr.open('POST', form.action);
+    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+    xhr.send(formData);
+}
+
 function handleFormSubmission() {
     const form = document.querySelector('form[method="post"]');
     const submitBtn = document.getElementById('submit-btn');
@@ -650,17 +899,43 @@ function handleFormSubmission() {
         
         // Update status
         updateUploadStatusText('{% trans "Preparing files..." %}');
-        
-        // Upload files via AJAX
+
+        const files = Array.from(fileInput.files);
+        const totalSize = files.reduce((sum, file) => sum + file.size, 0);
+
+        if (totalSize > CHUNKED_UPLOAD_THRESHOLD) {
+            try {
+                const uploadId = generateUploadId();
+                updateUploadStatusText('{% trans "Uploading files in chunks..." %}');
+
+                const chunkedFilesMeta = await uploadFilesInChunks(files, uploadId, (sent, total) => {
+                    const percentComplete = Math.round((sent / total) * 100);
+                    updateUploadStatusText(`{% trans "Uploading" %}: ${percentComplete}% (${formatFileSize(sent)} / ${formatFileSize(total)})`);
+                });
+
+                updateUploadStatusText('{% trans "Creating version..." %}');
+
+                const formData = new FormData(form);
+                formData.delete('files');
+                formData.append('upload_id', uploadId);
+                formData.append('chunked_files', JSON.stringify(chunkedFilesMeta));
+
+                submitVersionCreateRequest(formData, submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
+            } catch (error) {
+                console.error('Chunked upload failed:', error);
+                updateUploadStatusText('{% trans "Upload failed" %}');
+                alert(error.message || '{% trans "Chunk upload failed. Please try again." %}');
+                reEnableUploadForm(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
+            }
+            return;
+        }
+
+        // Upload files via AJAX (single request for smaller totals)
         const formData = new FormData(form);
         const xhr = new XMLHttpRequest();
         
         // Track overall progress
-        let totalSize = 0;
         let uploadedSize = 0;
-        Array.from(fileInput.files).forEach(file => {
-            totalSize += file.size;
-        });
         
         xhr.upload.addEventListener('progress', (e) => {
             if (e.lengthComputable && totalSize > 0) {
@@ -693,173 +968,16 @@ function handleFormSubmission() {
         });
         
         xhr.addEventListener('load', () => {
-            console.log('Upload response status:', xhr.status);
-            console.log('Upload response headers:', xhr.getAllResponseHeaders());
-            console.log('Upload response text (first 1000 chars):', xhr.responseText ? xhr.responseText.substring(0, 1000) : '(empty)');
-            
-            if (xhr.status === 200) {
-                // Check if response is JSON
-                try {
-                    const response = JSON.parse(xhr.responseText);
-                    console.log('Parsed JSON response:', response);
-                    
-                    if (response.success && response.redirect_url) {
-                        // Success - redirect
-                        window.location.href = response.redirect_url;
-                    } else if (response.error) {
-                        // Error response
-                        let errorMessage = response.error;
-                        
-                        // Add detailed error information if available
-                        if (response.errors) {
-                            errorMessage += '\n\nField errors:';
-                            for (const [field, errors] of Object.entries(response.errors)) {
-                                errorMessage += `\n- ${field}: ${Array.isArray(errors) ? errors.join(', ') : errors}`;
-                            }
-                        }
-                        
-                        if (response.non_field_errors && response.non_field_errors.length > 0) {
-                            errorMessage += '\n\nGeneral errors: ' + response.non_field_errors.join(', ');
-                        }
-                        
-                        if (response.error_details) {
-                            console.error('Detailed error:', response.error_details);
-                            errorMessage += '\n\n[Check browser console for full details]';
-                        }
-                        
-                        updateUploadStatusText('{% trans "Upload failed" %}: ' + response.error);
-                        alert(errorMessage);
-                        
-                        // Re-enable form
-                        if (submitBtn) submitBtn.disabled = false;
-                        if (submitBtnText) submitBtnText.textContent = '{% trans "Create Version" %}';
-                        if (submitBtnSpinner) submitBtnSpinner.style.display = 'none';
-                        if (cancelBtn) cancelBtn.disabled = false;
-                    } else {
-                        // Unexpected response format
-                        console.warn('Unexpected response format:', response);
-                        updateUploadStatusText('{% trans "Unexpected response from server" %}');
-                        alert('{% trans "Unexpected response from server. Please check the console for details." %}');
-                        if (submitBtn) submitBtn.disabled = false;
-                        if (submitBtnText) submitBtnText.textContent = '{% trans "Create Version" %}';
-                        if (submitBtnSpinner) submitBtnSpinner.style.display = 'none';
-                        if (cancelBtn) cancelBtn.disabled = false;
-                    }
-                } catch (e) {
-                    // Not JSON, might be HTML or redirect
-                    console.log('Response is not JSON, parsing as HTML. Error:', e);
-                    if (xhr.responseURL) {
-                        window.location.href = xhr.responseURL;
-                    } else {
-                        // Try to parse HTML for error messages
-                        const parser = new DOMParser();
-                        const doc = parser.parseFromString(xhr.responseText, 'text/html');
-                        const errorElements = doc.querySelectorAll('.alert-danger, .error, .invalid-feedback, .non-field-errors');
-                        let errorText = '{% trans "An error occurred. Server returned HTML response." %}';
-                        if (errorElements.length > 0) {
-                            errorText += '\n\n' + Array.from(errorElements).map(el => el.textContent.trim()).filter(text => text.length > 0).join('\n');
-                        }
-                        updateUploadStatusText('{% trans "Upload failed" %}');
-                        alert(errorText + '\n\n[Full response logged to console]');
-                        console.error('HTML response:', xhr.responseText);
-                        if (submitBtn) submitBtn.disabled = false;
-                        if (submitBtnText) submitBtnText.textContent = '{% trans "Create Version" %}';
-                        if (submitBtnSpinner) submitBtnSpinner.style.display = 'none';
-                        if (cancelBtn) cancelBtn.disabled = false;
-                    }
-                }
-            } else if (xhr.status === 302) {
-                // Redirect response
-                const location = xhr.getResponseHeader('Location');
-                if (location) {
-                    window.location.href = location;
-                } else if (xhr.responseURL) {
-                    window.location.href = xhr.responseURL;
-                } else {
-                    window.location.href = window.location.href;
-                }
-            } else if (xhr.status === 413) {
-                // Request Entity Too Large - specific handling
-                let errorMessage = '{% trans "Upload failed: File is too large" %}';
-                let details = '';
-                
-                // Calculate total file size
-                const fileInput = document.getElementById('{{ form.files.id_for_label }}');
-                if (fileInput && fileInput.files) {
-                    let totalSize = 0;
-                    Array.from(fileInput.files).forEach(file => {
-                        totalSize += file.size;
-                    });
-                    const totalSizeMB = (totalSize / (1024 * 1024)).toFixed(2);
-                    const totalSizeGB = (totalSize / (1024 * 1024 * 1024)).toFixed(2);
-                    details = `\n\n{% trans "Total file size" %}: ${totalSizeGB} GB (${totalSizeMB} MB)`;
-                    details += `\n{% trans "Maximum allowed size" %}: ${MAX_DATASET_UPLOAD_SIZE_GB} GB`;
-                }
-                
-                errorMessage += details;
-                errorMessage += '\n\n{% trans "Please either:" %}';
-                errorMessage += '\n1. {% trans "Compress your files before uploading" %}';
-                errorMessage += '\n2. {% trans "Split into smaller files" %}';
-                errorMessage += '\n3. {% trans "Contact administrator if you need to upload larger files" %}';
-                
-                updateUploadStatusText('{% trans "Upload failed: File too large" %}');
-                alert(errorMessage);
-                console.error('413 Request Entity Too Large - File size limit exceeded');
-                console.error('Response:', xhr.responseText);
-                
-                // Re-enable form
-                if (submitBtn) submitBtn.disabled = false;
-                if (submitBtnText) submitBtnText.textContent = '{% trans "Create Version" %}';
-                if (submitBtnSpinner) submitBtnSpinner.style.display = 'none';
-                if (cancelBtn) cancelBtn.disabled = false;
-            } else if (xhr.status === 502 || xhr.status === 504) {
-                console.error(`${xhr.status} gateway error during upload`);
-                console.error('Response:', xhr.responseText);
-                showServerTimeoutUploadError(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
-            } else {
-                // HTTP error status
-                let errorMessage = `{% trans "Upload failed" %} (HTTP ${xhr.status} ${xhr.statusText})`;
-                
-                try {
-                    const response = JSON.parse(xhr.responseText);
-                    console.error('Error response:', response);
-                    if (response.error) {
-                        errorMessage = response.error;
-                    }
-                    if (response.errors) {
-                        errorMessage += '\n\nField errors:';
-                        for (const [field, errors] of Object.entries(response.errors)) {
-                            errorMessage += `\n- ${field}: ${Array.isArray(errors) ? errors.join(', ') : errors}`;
-                        }
-                    }
-                    if (response.error_details) {
-                        console.error('Error details:', response.error_details);
-                        errorMessage += '\n\n[Check browser console for full details]';
-                    }
-                } catch (e) {
-                    // Not JSON
-                    errorMessage += '\n\nResponse: ' + (xhr.responseText ? xhr.responseText.substring(0, 500) : '(empty)');
-                    console.error('Error response text:', xhr.responseText);
-                }
-                
-                updateUploadStatusText(errorMessage);
-                alert(errorMessage + '\n\n{% trans "Please check the browser console for more details." %}');
-                
-                // Re-enable form
-                if (submitBtn) submitBtn.disabled = false;
-                if (submitBtnText) submitBtnText.textContent = '{% trans "Create Version" %}';
-                if (submitBtnSpinner) submitBtnSpinner.style.display = 'none';
-                if (cancelBtn) cancelBtn.disabled = false;
-            }
+            handleUploadXhrResponse(xhr, submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
         });
-        
+
         xhr.addEventListener('error', () => {
             console.error('Network error during upload');
             console.error('Status:', xhr.status);
             console.error('Status text:', xhr.statusText);
             console.error('Response:', xhr.responseText);
             console.error('Ready state:', xhr.readyState);
-            
+
             if (xhr.readyState === 4) {
                 showServerTimeoutUploadError(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
                 return;
@@ -867,19 +985,14 @@ function handleFormSubmission() {
 
             updateUploadStatusText('{% trans "Network error during upload" %}');
             alert('{% trans "Network error during upload. Please check your connection and try again." %}\n\n{% trans "Check the browser console (F12) for more details." %}');
-            
             reEnableUploadForm(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
         });
-        
+
         xhr.addEventListener('abort', () => {
             updateUploadStatusText('{% trans "Upload cancelled" %}');
-            // Re-enable form
-            if (submitBtn) submitBtn.disabled = false;
-            if (submitBtnText) submitBtnText.textContent = '{% trans "Create Version" %}';
-            if (submitBtnSpinner) submitBtnSpinner.style.display = 'none';
-            if (cancelBtn) cancelBtn.disabled = false;
+            reEnableUploadForm(submitBtn, submitBtnText, submitBtnSpinner, cancelBtn);
         });
-        
+
         updateUploadStatusText('{% trans "Starting upload..." %}');
         xhr.open('POST', form.action);
         xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,8 +60,11 @@ services:
       - "traefik.http.routers.dataplexity-isrdatasets.service=dataplexity-isrdatasets"
       - "traefik.http.services.dataplexity-isrdatasets.loadbalancer.server.port=80"
       - "traefik.http.services.dataplexity-isrdatasets.loadbalancer.responseforwarding.flushinterval=100ms"
+      - "traefik.http.middlewares.isr-longtimeout.forwardingtimeouts.dialtimeout=30s"
+      - "traefik.http.middlewares.isr-longtimeout.forwardingtimeouts.responseheadertimeout=3600s"
+      - "traefik.http.middlewares.isr-longtimeout.forwardingtimeouts.idleconntimeout=3600s"
       - "traefik.docker.network=proxy"
-      - "traefik.http.routers.dataplexity-isrdatasets.middlewares=default@file"
+      - "traefik.http.routers.dataplexity-isrdatasets.middlewares=isr-longtimeout,default@file"
     networks:
       - proxy
       - internal

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -319,7 +319,8 @@ The application is configured to handle large file uploads up to 100GB:
 - **Gunicorn**: 3 workers, `--timeout 3600` (1 hour)
 - **Nginx timeouts**: Extended to 3600s (1 hour) for large uploads
 - **Proxy**: Buffering disabled for better performance
-- **Traefik**: `responseforwarding.flushinterval=100ms` on the nginx service; host `default@file` middleware timeouts must also allow long uploads
+- **Traefik**: `isr-longtimeout` middleware (`forwardingTimeouts` 3600s) prepended before host `default@file`; `responseforwarding.flushinterval=100ms` on the nginx service; host entrypoint timeouts must also allow long uploads
+- **Browser (large uploads)**: Totals over 32MB are sent as sequential 8MB chunks, then the version is created from assembled temp files
 
 ### Why production uses gunicorn/WSGI
 
@@ -392,11 +393,23 @@ docker compose -f docker-compose.prod.yml restart nginx
 | **Django Data** | 100GB | - | Configured |
 | **Django Memory Spill** | 10MB | - | Configured |
 | **Proxy Buffering** | Disabled | - | Optimized |
-| **Traefik (host)** | - | Must match | Check `default@file` middleware |
+| **Traefik (compose)** | - | 3600s forwarding | `isr-longtimeout` middleware |
+| **Traefik (host)** | - | Must match | Check `default@file` middleware + entrypoint |
 
 ### Traefik on the host
 
-The router uses `default@file` middleware (outside this repo). For uploads over several GB, ensure Traefik entrypoint / middleware `respondingTimeouts.readTimeout` and `idleTimeout` are at least **3600s**, and that no body-size limit blocks the request before it reaches nginx.
+The router uses middleware chain `isr-longtimeout,default@file`. Compose defines `isr-longtimeout` with 3600s forwarding timeouts; `default@file` is configured on the host (outside this repo).
+
+For uploads over several GB, ensure Traefik entrypoint `readTimeout` / `idleTimeout` are at least **3600s**, and that no body-size limit blocks the request before it reaches nginx. Chunked uploads (8MB per request for totals over 32MB) reduce dependence on single-request proxy timeouts, but entrypoint limits should still be raised for any remaining single-request uploads.
+
+**Compose labels** (`docker-compose.prod.yml`):
+
+```yaml
+traefik.http.middlewares.isr-longtimeout.forwardingtimeouts.dialtimeout=30s
+traefik.http.middlewares.isr-longtimeout.forwardingtimeouts.responseheadertimeout=3600s
+traefik.http.middlewares.isr-longtimeout.forwardingtimeouts.idleconntimeout=3600s
+traefik.http.routers.dataplexity-isrdatasets.middlewares=isr-longtimeout,default@file
+```
 
 ### Troubleshooting Upload Issues
 
@@ -408,7 +421,7 @@ The router uses `default@file` middleware (outside this repo). For uploads over 
 
 2. **502 Bad Gateway / 504 Gateway Timeout**
    - **Cause**: App worker killed (often ASGI RAM buffering) or proxy timeout while waiting for Django to finish saving the file
-   - **Solution**: Use gunicorn/WSGI in production, confirm gunicorn and nginx timeouts are 3600s, raise Traefik `default@file` timeouts on the host
+   - **Solution**: Use gunicorn/WSGI in production, confirm gunicorn and nginx timeouts are 3600s, raise Traefik `default@file` and entrypoint timeouts on the host; for very large files the UI automatically uses 8MB chunked uploads when total size exceeds 32MB
 
 3. **500 Internal Server Error**
    - **Cause**: Django or disk space issues


### PR DESCRIPTION
- Added support for chunked uploads in the DatasetVersionForm, allowing files larger than 32MB to be uploaded in 8MB chunks.
- Introduced new views and utility functions for handling chunk uploads, including validation and assembly of uploaded chunks.
- Updated the dataset version creation process to accommodate chunked uploads and ensure proper validation of uploaded files.
- Enhanced the frontend JavaScript to manage chunk uploads, including retry logic and progress tracking.
- Updated documentation to reflect changes in upload handling and configuration for Traefik middleware timeouts.