### PR TITLE
Add latest download functionality for datasets

### DIFF
--- a/app/datasets/tests.py
+++ b/app/datasets/tests.py
@@ -1470,6 +1470,97 @@ class DatasetDownloadViewTests(TestCase):
         self.assertEqual(self.dataset.download_count, 1)
         self.assertEqual(DatasetDownload.objects.count(), 1)
 
+    def test_download_latest_serves_current_version(self):
+        """Latest download endpoint serves the version marked is_current."""
+        old_version = DatasetVersion.objects.create(
+            dataset=self.dataset,
+            version_number='0.9',
+            description='Older release',
+            created_by=self.owner,
+            is_current=False,
+        )
+        old_file = SimpleUploadedFile('old.csv', b'old,data\n')
+        DatasetVersionFile.objects.create(
+            version=old_version,
+            file=old_file,
+            file_size=old_file.size,
+            original_name='old.csv',
+        )
+
+        current_version = DatasetVersion.objects.create(
+            dataset=self.dataset,
+            version_number='2.0',
+            description='Current release',
+            created_by=self.owner,
+            is_current=True,
+        )
+        self.version.is_current = False
+        self.version.save(update_fields=['is_current'])
+
+        current_file = SimpleUploadedFile('current.csv', b'current,data\n')
+        current_attachment = DatasetVersionFile.objects.create(
+            version=current_version,
+            file=current_file,
+            file_size=current_file.size,
+            original_name='current.csv',
+        )
+
+        url = reverse('datasets:dataset_download_latest', args=[self.dataset.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(current_attachment.display_name, response.get('Content-Disposition', ''))
+
+    def test_download_latest_ignores_version_query_param(self):
+        """Latest download endpoint ignores ?version= and always uses current."""
+        old_version = DatasetVersion.objects.create(
+            dataset=self.dataset,
+            version_number='0.9',
+            description='Older release',
+            created_by=self.owner,
+            is_current=False,
+        )
+        old_file = SimpleUploadedFile('old.csv', b'old,data\n')
+        old_attachment = DatasetVersionFile.objects.create(
+            version=old_version,
+            file=old_file,
+            file_size=old_file.size,
+            original_name='old.csv',
+        )
+
+        url = reverse('datasets:dataset_download_latest', args=[self.dataset.pk])
+        response = self.client.get(url, {'version': old_version.id, 'file': old_attachment.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(self.attachment_one.display_name, response.get('Content-Disposition', ''))
+
+    def test_download_latest_without_versions_redirects(self):
+        """Latest download with no versions redirects to dataset detail."""
+        empty_dataset = Dataset.objects.create(
+            title='Empty Dataset',
+            description='No versions yet',
+            owner=self.owner,
+        )
+        url = reverse('datasets:dataset_download_latest', args=[empty_dataset.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('datasets:dataset_detail', args=[empty_dataset.pk]))
+
+    def test_download_latest_without_auth_returns_json_401(self):
+        """Unauthenticated API request to latest download returns JSON 401."""
+        self.client.logout()
+        url = reverse('datasets:dataset_download_latest', args=[self.dataset.pk])
+        response = self.client.get(url, HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 401)
+        self.assertIn('error', response.json())
+
+    def test_download_latest_without_auth_redirects(self):
+        """Unauthenticated browser request to latest download redirects to login."""
+        self.client.logout()
+        url = reverse('datasets:dataset_download_latest', args=[self.dataset.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/login/', response.url)
+
+
 class DatasetDeleteViewTests(TestCase):
     """Test cases for DatasetDeleteView - superuser only deletion"""
     

--- a/app/datasets/urls.py
+++ b/app/datasets/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('create/', views.DatasetCreateView.as_view(), name='dataset_create'),
     path('<uuid:pk>/edit/', views.DatasetUpdateView.as_view(), name='dataset_edit'),
     path('<uuid:pk>/delete/', views.DatasetDeleteView.as_view(), name='dataset_delete'),
+    path('<uuid:pk>/download/latest/', views.dataset_download, {'latest': True}, name='dataset_download_latest'),
     path('<uuid:pk>/download/', views.dataset_download, name='dataset_download'),
     path('<uuid:pk>/assign-project/', views.assign_dataset_to_project, name='assign_to_project'),
     path('<uuid:dataset_pk>/version/upload-chunk/', views.upload_dataset_version_chunk, name='dataset_version_upload_chunk'),

--- a/app/datasets/views.py
+++ b/app/datasets/views.py
@@ -324,7 +324,7 @@ class DatasetDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
         return super().delete(request, *args, **kwargs)
 
 
-def dataset_download(request, pk):
+def dataset_download(request, pk, latest=False):
     """Handle dataset downloads (requires authentication via session or API key)"""
     dataset = get_object_or_404(Dataset, pk=pk)
     
@@ -354,7 +354,11 @@ def dataset_download(request, pk):
     version_id = request.GET.get('version')
     version = None
 
-    if version_id:
+    if latest:
+        version = dataset.versions.filter(is_current=True).first()
+        if not version:
+            version = dataset.versions.order_by('-created_at').first()
+    elif version_id:
         try:
             version = dataset.versions.get(id=version_id)
         except DatasetVersion.DoesNotExist:

--- a/app/templates/datasets/dataset_detail.html
+++ b/app/templates/datasets/dataset_detail.html
@@ -363,7 +363,7 @@
                                 <tr>
                                     <td>
                                         <span class="badge bg-primary">v{{ version.version_number }}</span>
-                                        {% if forloop.first %}
+                                        {% if version.is_current %}
                                         <span class="badge bg-success ms-1">{% trans "Latest" %}</span>
                                         {% endif %}
                                     </td>

--- a/app/templates/user/settings.html
+++ b/app/templates/user/settings.html
@@ -489,6 +489,10 @@
                                         <p><strong>{% trans "Using Authorization Header" %}:</strong></p>
                                         <pre class="bg-dark text-light p-3 rounded"><code>curl -H "Authorization: Api-Key YOUR_API_KEY" \
   https://your-domain.com/datasets/DATASET_ID/download/</code></pre>
+
+                                        <p class="mt-3"><strong>{% trans "Download latest version" %}:</strong></p>
+                                        <pre class="bg-dark text-light p-3 rounded"><code>curl -H "Authorization: Api-Key YOUR_API_KEY" \
+  https://your-domain.com/datasets/DATASET_ID/download/latest/</code></pre>
                                         
                                         <p class="mt-3"><strong>{% trans "Using Query Parameter" %}:</strong></p>
                                         <pre class="bg-dark text-light p-3 rounded"><code>curl "https://your-domain.com/datasets/DATASET_ID/download/?api_key=YOUR_API_KEY"</code></pre>

--- a/app/user/tests.py
+++ b/app/user/tests.py
@@ -2985,3 +2985,16 @@ class APIKeyDatasetDownloadTests(TestCase):
         # Should redirect to login
         self.assertEqual(response.status_code, 302)
         self.assertIn('/login/', response.url)
+
+    def test_download_latest_with_api_key_header(self):
+        """Test downloading latest version with API key in Authorization header"""
+        url = reverse('datasets:dataset_download_latest', kwargs={'pk': self.dataset.pk})
+
+        response = self.client.get(
+            url,
+            HTTP_AUTHORIZATION=f'Api-Key {self.api_key.key}',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/octet-stream')
+        self.assertIn('attachment', response['Content-Disposition'])


### PR DESCRIPTION
- Implemented a new endpoint to serve the latest version of a dataset, ensuring it always returns the version marked as current.
- Updated the dataset download view to handle requests for the latest version, ignoring version query parameters.
- Added tests to verify the behavior of the latest download endpoint, including handling of unauthenticated requests and redirection for datasets without versions.
- Updated documentation to include usage examples for downloading the latest version via API key.